### PR TITLE
Add python-dotenv support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,4 +24,12 @@ Every ten cycles, the bot generates a chart of closing prices for each pair and 
 API keys for Binance should be provided via the environment variables `BINANCE_API_KEY` and `BINANCE_API_SECRET`.
 Set `DISCORD_WEBHOOK_URL` to receive periodic price charts for each coin on Discord.
 
+You can store these variables in a `.env` file and install [python-dotenv](https://pypi.org/project/python-dotenv/) so the script loads them automatically:
+
+```
+BINANCE_API_KEY=your_api_key
+BINANCE_API_SECRET=your_api_secret
+DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/...
+```
+
 This bot is an educational example and should not be used for real trading without further improvements and proper testing.

--- a/trade_bot.py
+++ b/trade_bot.py
@@ -1,6 +1,8 @@
 import os
 import time
 from typing import Dict, List
+
+from dotenv import load_dotenv
 import ccxt
 import pandas as pd
 import ta
@@ -121,6 +123,8 @@ class Trader:
 
 
 def main():
+    # Load environment variables from a `.env` file if present
+    load_dotenv()
     api_key = os.getenv('BINANCE_API_KEY', '')
     api_secret = os.getenv('BINANCE_API_SECRET', '')
     webhook = os.getenv('DISCORD_WEBHOOK_URL', '')


### PR DESCRIPTION
## Summary
- load variables from `.env` using `python-dotenv`
- document `.env` usage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686294476c14832e835976660b8e6ac1